### PR TITLE
chore: add FollowServiceDependency

### DIFF
--- a/app/routers/follow/dependencies.py
+++ b/app/routers/follow/dependencies.py
@@ -9,16 +9,18 @@ from app.db.database import get_db
 from app.services.follow_service import FollowService
 
 
-def get_follow_service(require_user: bool = False):
-    """Factory to enforce (or skip) auth dynamically per route."""
-    def _get_service(                                                
-        db: Session = Depends(get_db),
-        current_user: Optional[schemas.User] = Depends(get_current_user) if require_user else None,
-    ):
-        if require_user and current_user is None:
-            raise HTTPException(401, "Authentication required")
-        return FollowService(db, current_user)
-    return _get_service
+def get_service_with_user(
+    db: Session = Depends(get_db),
+    current_user: Optional[schemas.User] = Depends(get_current_user),
+) -> FollowService:
+    if current_user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return FollowService(db, current_user)
 
 
-FollowServiceDependency = Annotated[FollowService, Depends(get_follow_service)]
+def get_service(db: Session = Depends(get_db)) -> FollowService:
+    return FollowService(db, current_user=None)
+
+
+FollowServiceWithUser = Annotated[FollowService, Depends(get_service_with_user)]
+FollowServiceWithoutUser = Annotated[FollowService, Depends(get_service)]

--- a/app/routers/follow/dependencies.py
+++ b/app/routers/follow/dependencies.py
@@ -1,0 +1,24 @@
+from typing import Annotated, Optional
+from fastapi import Depends, HTTPException
+
+from sqlalchemy.orm import Session
+
+from app.auth.auth_utils import get_current_user
+from app.db import schemas
+from app.db.database import get_db
+from app.services.follow_service import FollowService
+
+
+def get_follow_service(require_user: bool = False):
+    """Factory to enforce (or skip) auth dynamically per route."""
+    def _get_service(                                                
+        db: Session = Depends(get_db),
+        current_user: Optional[schemas.User] = Depends(get_current_user) if require_user else None,
+    ):
+        if require_user and current_user is None:
+            raise HTTPException(401, "Authentication required")
+        return FollowService(db, current_user)
+    return _get_service
+
+
+FollowServiceDependency = Annotated[FollowService, Depends(get_follow_service)]

--- a/app/routers/follow/follow.py
+++ b/app/routers/follow/follow.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, status
 
 from app.db import schemas
 from app.auth.auth_utils import get_current_user
-from app.routers.follow.dependencies import FollowServiceDependency
+from app.routers.follow.dependencies import FollowServiceWithUser
 
 logger = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(get_current_user)])
@@ -15,7 +15,7 @@ router = APIRouter(dependencies=[Depends(get_current_user)])
     "/{user_id}", status_code=status.HTTP_201_CREATED,
 )
 def follow_user(
-    user_id: int, service: FollowServiceDependency,
+    user_id: int, service: FollowServiceWithUser,
 ):
     logger.info("follow_user endpoint has been called")
     return service.follow_user(user_id)
@@ -25,7 +25,7 @@ def follow_user(
     "/{user_id}", status_code=status.HTTP_202_ACCEPTED,
 )
 def unfollow(
-    user_id: int, service: FollowServiceDependency,
+    user_id: int, service: FollowServiceWithUser,
 ):
     logger.info(f"unfollow_user endpoint has been called with userId: {user_id}")
     return service.unfollow_user(user_id)
@@ -37,7 +37,7 @@ def unfollow(
     response_model=List[schemas.UserSummary],
 )
 def get_following(
-    service: FollowServiceDependency,
+    service: FollowServiceWithUser,
     alt_user: Optional[int] = None,
 ):
     logger.info("get_following endpoint has been called")
@@ -50,7 +50,7 @@ def get_following(
     response_model=List[schemas.UserSummary],
 )
 def get_followers(
-    service: FollowServiceDependency,
+    service: FollowServiceWithUser,
     alt_user: Optional[int] = None,
 ):
     logger.info(f"get_followers endpoint has been called with alt_user: {alt_user}")

--- a/app/routers/follow/follow.py
+++ b/app/routers/follow/follow.py
@@ -1,47 +1,57 @@
-from fastapi import APIRouter, HTTPException, Depends, status
-from sqlalchemy.orm import Session
+import logging
 from typing import List, Optional
-from app.db.database import get_db
+
+from fastapi import APIRouter, Depends, status
+
 from app.db import schemas
 from app.auth.auth_utils import get_current_user
-from app.services.follow_service import FollowService
-import logging
+from app.routers.follow.dependencies import FollowServiceDependency
 
 logger = logging.getLogger(__name__)
-
-router = APIRouter(dependencies= [Depends(get_current_user)])
-
-def get_follow_service(require_user: bool = False):
-    """Factory to enforce (or skip) auth dynamically per route."""
-    def _get_service(                                                
-        db: Session = Depends(get_db),
-        current_user: Optional[schemas.User] = Depends(get_current_user) if require_user else None,
-    ):
-        if require_user and current_user is None:
-            raise HTTPException(401, "Authentication required")
-        return FollowService(db, current_user)
-    return _get_service
-
-@router.post('/{userId}', status_code=status.HTTP_201_CREATED)
-def follow_user(userId: int, service: FollowService = Depends(get_follow_service(True))):
-    logger.info(f"follow_user endpoint has been called")
-    return service.follow_user(userId)
-
-@router.delete('/{userId}', status_code=status.HTTP_202_ACCEPTED)
-def unfollow(userId: int, service: FollowService = Depends(get_follow_service(True))):
-    logger.info(f"unfollow_user endpoint has been called with userId: {userId}")
-    return service.unfollow_user(userId)
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
-@router.get('/following', status_code=status.HTTP_200_OK)
-def get_following(alt_user: Optional[int] = None, service: FollowService = Depends(get_follow_service(True))) -> List[schemas.UserSummary]:
-    logger.info(f"get_following endpoint has been called")
+@router.post(
+    "/{user_id}", status_code=status.HTTP_201_CREATED,
+)
+def follow_user(
+    user_id: int, service: FollowServiceDependency,
+):
+    logger.info("follow_user endpoint has been called")
+    return service.follow_user(user_id)
+
+
+@router.delete(
+    "/{user_id}", status_code=status.HTTP_202_ACCEPTED,
+)
+def unfollow(
+    user_id: int, service: FollowServiceDependency,
+):
+    logger.info(f"unfollow_user endpoint has been called with userId: {user_id}")
+    return service.unfollow_user(user_id)
+
+
+@router.get(
+    "/following",
+    status_code=status.HTTP_200_OK,
+    response_model=List[schemas.UserSummary],
+)
+def get_following(
+    service: FollowServiceDependency,
+    alt_user: Optional[int] = None,
+):
+    logger.info("get_following endpoint has been called")
     return service.get_following(alt_user)
 
-@router.get('/followers', status_code=status.HTTP_200_OK)
-def get_followers(alt_user: Optional[int] = None, service: FollowService = Depends(get_follow_service(True))) -> List[schemas.UserSummary]:
+
+@router.get(
+    "/followers",
+    status_code=status.HTTP_200_OK,
+    response_model=List[schemas.UserSummary],
+)
+def get_followers(
+    service: FollowServiceDependency,
+    alt_user: Optional[int] = None,
+):
     logger.info(f"get_followers endpoint has been called with alt_user: {alt_user}")
     return service.get_followers(alt_user)
-
-
-# *, ALLOWS YOU TO LIST PARAMS IN ANY ORDER.... So query before default params: From tomi fast api (36:52)e.t.c


### PR DESCRIPTION
Change get_follow_service to FollowServiceDependency

```python
def get_follow_service(require_user: bool = False):
    """Factory to enforce (or skip) auth dynamically per route."""
    def _get_service(                                                
        db: Session = Depends(get_db),
        current_user: Optional[schemas.User] = Depends(get_current_user) if require_user else None,
    ):
        if require_user and current_user is None:
            raise HTTPException(401, "Authentication required")
        return FollowService(db, current_user)
    return _get_service


FollowServiceDependency = Annotated[FollowService, Depends(get_follow_service)]
```

Add that dependency to endpoints in follow.py
```python
@router.post(
    "/{user_id}", status_code=status.HTTP_201_CREATED,
)
def follow_user(
    user_id: int, service: FollowServiceDependency,
):
    logger.info("follow_user endpoint has been called")
    return service.follow_user(user_id)
```